### PR TITLE
dfe-analytics-dataform upgrade to version 2.0.0-pre6 to support hidde…

### DIFF
--- a/definitions/dfe_analytics_dataform_ccbl.js
+++ b/definitions/dfe_analytics_dataform_ccbl.js
@@ -1,11 +1,12 @@
 const dfeAnalyticsDataform = require("dfe-analytics-dataform");
 
 dfeAnalyticsDataform({
-  eventSourceName: "ccbl",
-  bqProjectName: "teaching-qualifications",
-  bqDatasetName: "ccbl_events_production",
-  bqEventsTableName: "events",
-  urlRegex: "check-the-childrens-barred-list.education.gov.uk",
-  transformEntityEvents: false,
-  dataSchema: []
+    eventSourceName: "ccbl",
+    bqProjectName: "teaching-qualifications",
+    bqDatasetName: "ccbl_events_production",
+    bqEventsTableName: "events",
+    urlRegex: "check-the-childrens-barred-list.education.gov.uk",
+    transformEntityEvents: false,
+    hiddenPolicyTagLocation: "projects/teaching-qualifications/locations/europe-west2/taxonomies/5159319666739647034/policyTags/2606812594222933114",
+    dataSchema: []
 });

--- a/definitions/dfe_analytics_dataform_ccbl_entity_tables.js
+++ b/definitions/dfe_analytics_dataform_ccbl_entity_tables.js
@@ -6,122 +6,126 @@ dfeAnalyticsDataform({
     bqDatasetName: "ccbl_events_production",
     bqEventsTableName: "events",
     urlRegex: "(?i)(check-the-childrens-barred-list.education.gov.uk)",
+    hiddenPolicyTagLocation: "projects/teaching-qualifications/locations/europe-west2/taxonomies/5159319666739647034/policyTags/2606812594222933114",
     dataSchema: [{
-        entityTableName: "search_logs",
-        description: "",
-        keys: [{
-                keyName: "dsi_user_id",
-                dataType: "string",
-                description: "",
-            },
-            {
-                keyName: "last_name",
-                dataType: "string",
-                description: "",
-            },
-            {
-                keyName: "date_of_birth",
-                dataType: "string",
-                description: "",
-            },
-            {
-                keyName: "result_returned",
-                dataType: "string",
-                description: "",
-            },],
-    }, 
-    {
-        entityTableName: "feedbacks",
-        description: "",
-        keys: [{
-                keyName: "satisfaction_rating",
-                dataType: "string",
-                description: "",
-            },
-            {
-                keyName: "improvement_suggestion",
-                dataType: "string",
-                description: "",
-            },
-            {
-                keyName: "contact_permission_given",
-                dataType: "boolean",
-                description: "",
-            },
-            {
-                keyName: "email",
-                dataType: "string",
-                description: "",
-            },],
-    },
-    {
-        entityTableName: "dsi_users",
-        description: "",
-        keys: [{
-                keyName: "uid",
-                dataType: "string",
-                description: "",
-            },
-            {
-                keyName: "staff",
-                dataType: "string",
-                description: "",
-            },
-            {
-                keyName: "email",
-                dataType: "string",
-                description: "",
-            },
-                                    {
-                            keyName: "first_name",
-                            dataType: "string",
-                            description: "",
-                        },
-                        {
-                            keyName: "last_name",
-                            dataType: "string",
-                            description: "",
-                        },
-                        {
-                            keyName: "terms_and_conditions_accepted_at",
-                            dataType: "string",
-                            description: "",
-                        },
-                        {
-                            keyName: "terms_and_conditions_version_accepted",
-                            dataType: "string",
-                            description: "",
-                        },
-                        ],   
+            entityTableName: "search_logs",
+            description: "",
+            keys: [{
+                    keyName: "dsi_user_id",
+                    dataType: "string",
+                    description: "",
+                },
+                {
+                    keyName: "last_name",
+                    dataType: "string",
+                    description: "",
+                },
+                {
+                    keyName: "date_of_birth",
+                    dataType: "string",
+                    description: "",
+                },
+                {
+                    keyName: "result_returned",
+                    dataType: "string",
+                    description: "",
+                },
+            ],
         },
-    {
-        entityTableName: "dsi_user_sessions",
-        description: "",
-        keys: [{
-                keyName: "dsi_user_id",
-                dataType: "string",
-                description: "",
-            },
-            {
-                keyName: "role_id",
-                dataType: "string",
-                description: "",
-            },
-            {
-                keyName: "role_code",
-                dataType: "string",
-                description: "",
-            },
-            {
-                keyName: "organisation_id",
-                dataType: "string",
-                description: "",
-            },
-            {
-                keyName: "organisation_name",
-                dataType: "string",
-                description: "",
-            },],   
+        {
+            entityTableName: "feedbacks",
+            description: "",
+            keys: [{
+                    keyName: "satisfaction_rating",
+                    dataType: "string",
+                    description: "",
+                },
+                {
+                    keyName: "improvement_suggestion",
+                    dataType: "string",
+                    description: "",
+                },
+                {
+                    keyName: "contact_permission_given",
+                    dataType: "boolean",
+                    description: "",
+                },
+                {
+                    keyName: "email",
+                    dataType: "string",
+                    description: "",
+                },
+            ],
+        },
+        {
+            entityTableName: "dsi_users",
+            description: "",
+            keys: [{
+                    keyName: "uid",
+                    dataType: "string",
+                    description: "",
+                },
+                {
+                    keyName: "staff",
+                    dataType: "string",
+                    description: "",
+                },
+                {
+                    keyName: "email",
+                    dataType: "string",
+                    description: "",
+                },
+                {
+                    keyName: "first_name",
+                    dataType: "string",
+                    description: "",
+                },
+                {
+                    keyName: "last_name",
+                    dataType: "string",
+                    description: "",
+                },
+                {
+                    keyName: "terms_and_conditions_accepted_at",
+                    dataType: "string",
+                    description: "",
+                },
+                {
+                    keyName: "terms_and_conditions_version_accepted",
+                    dataType: "string",
+                    description: "",
+                },
+            ],
+        },
+        {
+            entityTableName: "dsi_user_sessions",
+            description: "",
+            keys: [{
+                    keyName: "dsi_user_id",
+                    dataType: "string",
+                    description: "",
+                },
+                {
+                    keyName: "role_id",
+                    dataType: "string",
+                    description: "",
+                },
+                {
+                    keyName: "role_code",
+                    dataType: "string",
+                    description: "",
+                },
+                {
+                    keyName: "organisation_id",
+                    dataType: "string",
+                    description: "",
+                },
+                {
+                    keyName: "organisation_name",
+                    dataType: "string",
+                    description: "",
+                },
+            ],
         },
     ],
 });

--- a/definitions/dfe_analytics_dataform_check_record.js
+++ b/definitions/dfe_analytics_dataform_check_record.js
@@ -7,6 +7,7 @@ dfeAnalyticsDataform({
     bqEventsTableName: "events",
     bqEventsTableNameSpace: "check-a-teachers-record",
     urlRegex: "check-a-teachers-record.education.gov.uk",
-  transformEntityEvents: false,
-  dataSchema: []
+    transformEntityEvents: false,
+    hiddenPolicyTagLocation: "projects/teaching-qualifications/locations/europe-west2/taxonomies/5159319666739647034/policyTags/2606812594222933114",
+    dataSchema: []
 });

--- a/definitions/dfe_analytics_dataform_entity_tables.js
+++ b/definitions/dfe_analytics_dataform_entity_tables.js
@@ -6,6 +6,7 @@ dfeAnalyticsDataform({
             bqDatasetName: "events_production",
             bqEventsTableName: "events",
             urlRegex: "(?i)(check-a-teachers-record.education.gov.uk|access-your-teaching-qualifications.education.gov.uk)",
+            hiddenPolicyTagLocation: "projects/teaching-qualifications/locations/europe-west2/taxonomies/5159319666739647034/policyTags/2606812594222933114",
             dataSchema: [{
                     entityTableName: "search_logs",
                     description: "",

--- a/definitions/dfe_analytics_dataform_teaching_qualifications.js
+++ b/definitions/dfe_analytics_dataform_teaching_qualifications.js
@@ -8,5 +8,6 @@ dfeAnalyticsDataform({
     bqEventsTableNameSpace: "access-your-teaching-qualifications",
     urlRegex: "access-your-teaching-qualifications.education.gov.uk",
     transformEntityEvents: false,
+    hiddenPolicyTagLocation: "projects/teaching-qualifications/locations/europe-west2/taxonomies/5159319666739647034/policyTags/2606812594222933114",
     dataSchema: []
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
         "": {
             "dependencies": {
                 "@dataform/core": "3.0.0",
-                "dfe-analytics-dataform": "https://github.com/DFE-Digital/dfe-analytics-dataform/archive/refs/tags/v1.12.5.tar.gz"
+                "dfe-analytics-dataform": "https://github.com/DFE-Digital/dfe-analytics-dataform/archive/refs/tags/v2.0.0-pre6.tar.gz"
             }
         },
         "node_modules/@dataform/core": {
@@ -15,16 +15,11 @@
             "integrity": "sha512-MORO8ADZkkPfAHH0S/jb3o/6HOYT4klw+hCgyHkNInFTnIYAN+zzgHc9++FrtXNyer0MvnZ351XTBveIVw7tcg=="
         },
         "node_modules/dfe-analytics-dataform": {
-            "resolved": "https://github.com/DFE-Digital/dfe-analytics-dataform/archive/refs/tags/v1.12.5.tar.gz",
-            "integrity": "sha512-G/veBdIgKWlrKYfpT3bX22m+ItxWkesUouggav+yJ+ErZw1wH2skzPcvczz2ff+gV09Rnuf49bkym/p0VJ40SA==",
+            "resolved": "https://github.com/DFE-Digital/dfe-analytics-dataform/archive/refs/tags/v2.0.0-pre6.tar.gz",
+            "integrity": "sha512-rMuGug7zO6nWtjplEiugrAqKINuGj6xZJ+1ta29cHvwA3K3rEIDJuyhFnVtYLGwpEb8KAk2QE1mTkmBjA4NPeg==",
             "dependencies": {
-                "@dataform/core": "3.0.0-beta.5"
+                "@dataform/core": "3.0.0"
             }
-        },
-        "node_modules/dfe-analytics-dataform/node_modules/@dataform/core": {
-            "version": "3.0.0-beta.5",
-            "resolved": "https://registry.npmjs.org/@dataform/core/-/core-3.0.0-beta.5.tgz",
-            "integrity": "sha512-t9i0lIhfHG1gNZY/sYokZ5kpzsYWMTPPBa2r1+ZZaY3Um8SFK7rc84ckGlvtv81n4r7U4yunaz9pMpqNb4Gyng=="
         }
     },
     "dependencies": {
@@ -34,17 +29,10 @@
             "integrity": "sha512-MORO8ADZkkPfAHH0S/jb3o/6HOYT4klw+hCgyHkNInFTnIYAN+zzgHc9++FrtXNyer0MvnZ351XTBveIVw7tcg=="
         },
         "dfe-analytics-dataform": {
-            "version": "https://github.com/DFE-Digital/dfe-analytics-dataform/archive/refs/tags/v1.12.5.tar.gz",
-            "integrity": "sha512-G/veBdIgKWlrKYfpT3bX22m+ItxWkesUouggav+yJ+ErZw1wH2skzPcvczz2ff+gV09Rnuf49bkym/p0VJ40SA==",
+            "version": "https://github.com/DFE-Digital/dfe-analytics-dataform/archive/refs/tags/v2.0.0-pre6.tar.gz",
+            "integrity": "sha512-rMuGug7zO6nWtjplEiugrAqKINuGj6xZJ+1ta29cHvwA3K3rEIDJuyhFnVtYLGwpEb8KAk2QE1mTkmBjA4NPeg==",
             "requires": {
-                "@dataform/core": "3.0.0-beta.5"
-            },
-            "dependencies": {
-                "@dataform/core": {
-                    "version": "3.0.0-beta.5",
-                    "resolved": "https://registry.npmjs.org/@dataform/core/-/core-3.0.0-beta.5.tgz",
-                    "integrity": "sha512-t9i0lIhfHG1gNZY/sYokZ5kpzsYWMTPPBa2r1+ZZaY3Um8SFK7rc84ckGlvtv81n4r7U4yunaz9pMpqNb4Gyng=="
-                }
+                "@dataform/core": "3.0.0"
             }
         }
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "dependencies": {
         "@dataform/core": "3.0.0",
-        "dfe-analytics-dataform": "https://github.com/DFE-Digital/dfe-analytics-dataform/archive/refs/tags/v1.12.5.tar.gz"
+        "dfe-analytics-dataform": "https://github.com/DFE-Digital/dfe-analytics-dataform/archive/refs/tags/v2.0.0-pre6.tar.gz"
     }
 }


### PR DESCRIPTION
dfe-analytics-dataform upgrade to version 2.0.0-pre6 to support hidden PII.

also added the PolicyTag to the javascript configuration files. 

Note there have been no deletions to the entries in the .js files but the formatting has changed slightly and this is why there are changes being reported to large part of some configurations.