### PR TITLE
Update to latest version of dfe-analytics, resolved on-going pipeline alerts

### DIFF
--- a/definitions/dfe_analytics_dataform_ccbl.js
+++ b/definitions/dfe_analytics_dataform_ccbl.js
@@ -8,5 +8,6 @@ dfeAnalyticsDataform({
     urlRegex: "check-the-childrens-barred-list.education.gov.uk",
     transformEntityEvents: false,
     hiddenPolicyTagLocation: "projects/teaching-qualifications/locations/europe-west2/taxonomies/5159319666739647034/policyTags/2606812594222933114",
-    dataSchema: []
+    dataSchema: [],
+    expirationDays: false
 });

--- a/definitions/dfe_analytics_dataform_ccbl.js
+++ b/definitions/dfe_analytics_dataform_ccbl.js
@@ -5,6 +5,7 @@ dfeAnalyticsDataform({
     bqProjectName: "teaching-qualifications",
     bqDatasetName: "ccbl_events_production",
     bqEventsTableName: "events",
+    enableMonitoring: false,
     urlRegex: "check-the-childrens-barred-list.education.gov.uk",
     transformEntityEvents: false,
     hiddenPolicyTagLocation: "projects/teaching-qualifications/locations/europe-west2/taxonomies/5159319666739647034/policyTags/2606812594222933114",

--- a/definitions/dfe_analytics_dataform_ccbl_entity_tables.js
+++ b/definitions/dfe_analytics_dataform_ccbl_entity_tables.js
@@ -7,6 +7,7 @@ dfeAnalyticsDataform({
     bqEventsTableName: "events",
     urlRegex: "(?i)(check-the-childrens-barred-list.education.gov.uk)",
     hiddenPolicyTagLocation: "projects/teaching-qualifications/locations/europe-west2/taxonomies/5159319666739647034/policyTags/2606812594222933114",
+    expirationDays: false,
     dataSchema: [{
             entityTableName: "search_logs",
             description: "",
@@ -25,7 +26,7 @@ dfeAnalyticsDataform({
                     keyName: "date_of_birth",
                     dataType: "string",
                     description: "",
-                    hidden:true,
+                    hidden: true,
                 },
                 {
                     keyName: "result_returned",
@@ -78,7 +79,7 @@ dfeAnalyticsDataform({
                     keyName: "email",
                     dataType: "string",
                     description: "",
-                    hidden:true,
+                    hidden: true,
                 },
                 {
                     keyName: "first_name",

--- a/definitions/dfe_analytics_dataform_ccbl_entity_tables.js
+++ b/definitions/dfe_analytics_dataform_ccbl_entity_tables.js
@@ -71,11 +71,6 @@ dfeAnalyticsDataform({
                     hidden: true,
                 },
                 {
-                    keyName: "staff",
-                    dataType: "string",
-                    description: "",
-                },
-                {
                     keyName: "email",
                     dataType: "string",
                     description: "",

--- a/definitions/dfe_analytics_dataform_check_record.js
+++ b/definitions/dfe_analytics_dataform_check_record.js
@@ -6,6 +6,7 @@ dfeAnalyticsDataform({
     bqDatasetName: "events_production",
     bqEventsTableName: "events",
     bqEventsTableNameSpace: "check-a-teachers-record",
+    enableMonitoring: false,
     urlRegex: "check-a-teachers-record.education.gov.uk",
     transformEntityEvents: false,
     hiddenPolicyTagLocation: "projects/teaching-qualifications/locations/europe-west2/taxonomies/5159319666739647034/policyTags/2606812594222933114",

--- a/definitions/dfe_analytics_dataform_check_record.js
+++ b/definitions/dfe_analytics_dataform_check_record.js
@@ -9,5 +9,6 @@ dfeAnalyticsDataform({
     urlRegex: "check-a-teachers-record.education.gov.uk",
     transformEntityEvents: false,
     hiddenPolicyTagLocation: "projects/teaching-qualifications/locations/europe-west2/taxonomies/5159319666739647034/policyTags/2606812594222933114",
+    expirationDays: false,
     dataSchema: []
 });

--- a/definitions/dfe_analytics_dataform_entity_tables.js
+++ b/definitions/dfe_analytics_dataform_entity_tables.js
@@ -269,6 +269,108 @@ dfeAnalyticsDataform({
                     description: "",
                 }
             ],
+        },
+        {
+            entityTableName: "active_storage_attachments",
+            description: "",
+            keys: [{
+                    keyName: "blob_id",
+                    dataType: "string",
+                    description: "",
+                },
+                {
+                    keyName: "name",
+                    dataType: "string",
+                    description: "",
+                },
+                {
+                    keyName: "record_id",
+                    dataType: "string",
+                    description: "",
+                },
+                {
+                    keyName: "record_type",
+                    dataType: "string",
+                    description: "",
+                }
+            ],
+        },
+        {
+            entityTableName: "active_storage_blobs",
+            description: "",
+            keys: [{
+                    keyName: "byte_size",
+                    dataType: "string",
+                    description: "",
+                },
+                {
+                    keyName: "checksum",
+                    dataType: "string",
+                    description: "",
+                },
+                {
+                    keyName: "content_type",
+                    dataType: "string",
+                    description: "",
+                },
+                {
+                    keyName: "filename",
+                    dataType: "string",
+                    description: "",
+                },
+                {
+                    keyName: "key",
+                    dataType: "string",
+                    description: "",
+                },
+                {
+                    keyName: "metadata",
+                    dataType: "string",
+                    description: "",
+                },
+                {
+                    keyName: "service_name",
+                    dataType: "string",
+                    description: "",
+                }
+            ],
+        },
+
+        {
+            entityTableName: "name_changes",
+            description: "",
+            keys: [{
+                    keyName: "first_name",
+                    dataType: "string",
+                    description: "",
+                },
+                {
+                    keyName: "last_name",
+                    dataType: "string",
+                    description: "",
+                },
+                {
+                    keyName: "middle_name",
+                    dataType: "string",
+                    description: "",
+                },
+                {
+                    keyName: "reference_number",
+                    dataType: "string",
+                    description: "",
+                },
+                {
+                    keyName: "user_id",
+                    dataType: "string",
+                    description: "",
+                },
+                {
+                    keyName: "malware_scan_result",
+                    dataType: "string",
+                    description: "",
+                }
+            ],
         }
+
     ],
 });

--- a/definitions/dfe_analytics_dataform_entity_tables.js
+++ b/definitions/dfe_analytics_dataform_entity_tables.js
@@ -7,6 +7,7 @@ dfeAnalyticsDataform({
     bqEventsTableName: "events",
     urlRegex: "(?i)(check-a-teachers-record.education.gov.uk|access-your-teaching-qualifications.education.gov.uk)",
     hiddenPolicyTagLocation: "projects/teaching-qualifications/locations/europe-west2/taxonomies/5159319666739647034/policyTags/2606812594222933114",
+    expirationDays: false,
     dataSchema: [{
             entityTableName: "search_logs",
             description: "",

--- a/definitions/dfe_analytics_dataform_entity_tables.js
+++ b/definitions/dfe_analytics_dataform_entity_tables.js
@@ -80,11 +80,6 @@ dfeAnalyticsDataform({
                     description: "",
                 },
                 {
-                    keyName: "staff",
-                    dataType: "string",
-                    description: "",
-                },
-                {
                     keyName: "email",
                     dataType: "string",
                     description: "",

--- a/definitions/dfe_analytics_dataform_entity_tables.js
+++ b/definitions/dfe_analytics_dataform_entity_tables.js
@@ -343,16 +343,19 @@ dfeAnalyticsDataform({
                     keyName: "first_name",
                     dataType: "string",
                     description: "",
+                    hidden: true
                 },
                 {
                     keyName: "last_name",
                     dataType: "string",
                     description: "",
+                    hidden: true
                 },
                 {
                     keyName: "middle_name",
                     dataType: "string",
                     description: "",
+                    hidden: true
                 },
                 {
                     keyName: "reference_number",

--- a/definitions/dfe_analytics_dataform_entity_tables.js
+++ b/definitions/dfe_analytics_dataform_entity_tables.js
@@ -220,8 +220,7 @@ dfeAnalyticsDataform({
                 }, {
                     keyName: "csv",
                     dataType: "string",
-                    description: "",
-                    hidden: true,
+                    description: ""
                 },
             ],
         },
@@ -276,6 +275,7 @@ dfeAnalyticsDataform({
                 {
                     keyName: "name",
                     dataType: "string",
+                    hidden: true,
                     description: "",
                 },
                 {
@@ -311,6 +311,7 @@ dfeAnalyticsDataform({
                 {
                     keyName: "filename",
                     dataType: "string",
+                    hidden: true,
                     description: "",
                 },
                 {

--- a/definitions/dfe_analytics_dataform_teaching_qualifications.js
+++ b/definitions/dfe_analytics_dataform_teaching_qualifications.js
@@ -6,6 +6,7 @@ dfeAnalyticsDataform({
     bqDatasetName: "events_production",
     bqEventsTableName: "events",
     bqEventsTableNameSpace: "access-your-teaching-qualifications",
+    enableMonitoring: false,
     urlRegex: "access-your-teaching-qualifications.education.gov.uk",
     transformEntityEvents: false,
     hiddenPolicyTagLocation: "projects/teaching-qualifications/locations/europe-west2/taxonomies/5159319666739647034/policyTags/2606812594222933114",

--- a/definitions/dfe_analytics_dataform_teaching_qualifications.js
+++ b/definitions/dfe_analytics_dataform_teaching_qualifications.js
@@ -9,5 +9,6 @@ dfeAnalyticsDataform({
     urlRegex: "access-your-teaching-qualifications.education.gov.uk",
     transformEntityEvents: false,
     hiddenPolicyTagLocation: "projects/teaching-qualifications/locations/europe-west2/taxonomies/5159319666739647034/policyTags/2606812594222933114",
-    dataSchema: []
+    dataSchema: [],
+    expirationDays: false
 });

--- a/definitions/operations/delete_inactive_datasets.sqlx
+++ b/definitions/operations/delete_inactive_datasets.sqlx
@@ -1,0 +1,62 @@
+-- Declare a variable to act as the threshold for the number of days since any table was last updated in this schema
+DECLARE
+  days_since_last_update INT64 DEFAULT 30;
+  -- Declare a variable for the project id. This can be modified in other projects to their respective IDs.
+DECLARE
+  projectid STRING DEFAULT '${dataform.projectConfig.defaultDatabase}';
+  -- Declare a variable for the region where the datasets are stored. Teacher Services projects should be in 'region-europe-west2'
+DECLARE
+  region STRING DEFAULT 'region-europe-west2';
+  -- Create a temporary table to store datasets information in this project
+DECLARE
+  drop_schema_sql STRING;
+BEGIN
+EXECUTE IMMEDIATE
+  FORMAT("""
+  CREATE TEMP TABLE datasets_in_project AS (
+    SELECT
+      table_catalog AS project_name,
+      table_schema AS dataset_name,
+      MAX(creation_time) AS last_run,
+      DATE_DIFF(CURRENT_DATE, MAX(DATE(creation_time)), DAY) AS days_since_last_run
+    FROM
+      `%s`.`%s`.INFORMATION_SCHEMA.TABLES
+    WHERE
+      -- Only detects datasets beginning with 'dataform', and featuring the word 'dev', but does not delete 'dataform' or 'dataform_assertions' explicitly
+      REGEXP_CONTAINS(LOWER(table_schema), r'^dataform_')
+      AND REGEXP_CONTAINS(LOWER(table_schema), 'dev')
+      AND NOT (LOWER(table_schema)= 'dataform_assertions'
+        OR LOWER(table_schema)= 'dataform')
+    GROUP BY
+      project_name,
+      dataset_name
+    HAVING
+      DATE_DIFF(CURRENT_DATE, MAX(DATE(creation_time)), DAY) > %d
+    ORDER BY
+      days_since_last_run DESC
+    );
+  """, projectid, region, days_since_last_update);
+END
+  ;
+  -- Begin SQLX procedure to loop through the datasets
+BEGIN
+  -- Loop through each dataset in the temporary table `datasets_in_project`
+  FOR dataset_row IN (
+  SELECT
+    project_name,
+    dataset_name,
+    days_since_last_run
+  FROM
+    datasets_in_project ) DO
+  -- Step to drop the schema
+SET
+  drop_schema_sql = FORMAT("""
+      DROP SCHEMA IF EXISTS `%s.%s` CASCADE
+    """, dataset_row.project_name, dataset_row.dataset_name);
+  -- Execute the DROP SCHEMA statement
+EXECUTE IMMEDIATE
+  drop_schema_sql;
+END
+  FOR;
+END
+  ;

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,34 +5,34 @@
     "packages": {
         "": {
             "dependencies": {
-                "@dataform/core": "3.0.2",
-                "dfe-analytics-dataform": "https://github.com/DFE-Digital/dfe-analytics-dataform/archive/refs/tags/v2.1.0-pre4.tar.gz"
+                "@dataform/core": "3.0.45",
+                "dfe-analytics-dataform": "https://github.com/DFE-Digital/dfe-analytics-dataform/archive/refs/tags/v2.4.2.tar.gz"
             }
         },
         "node_modules/@dataform/core": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/@dataform/core/-/core-3.0.2.tgz",
-            "integrity": "sha512-W1DQuv1vSsQgUPlNXuBTqa927FfNp5pNswOTz0wlX3cJTk5OT0UEENVmVJu/WIEdoVcCRTn8pn2dNNc1IjtMcA=="
+            "version": "3.0.45",
+            "resolved": "https://registry.npmjs.org/@dataform/core/-/core-3.0.45.tgz",
+            "integrity": "sha512-jXCF8fHbGE6ESBKwrDYGnoukzrr6bOpbEKhwacEGE4MKKkZHq7dfv+V/QNz7mDqaGQokLGLzHxcgzDYwgka++A=="
         },
         "node_modules/dfe-analytics-dataform": {
-            "resolved": "https://github.com/DFE-Digital/dfe-analytics-dataform/archive/refs/tags/v2.1.0-pre4.tar.gz",
-            "integrity": "sha512-s3yN7m/01kHi7fq3PGYmgEKn1QMEz0z40S32wQVOX9XR69GD1RKiq96tT8DYZX/QZWShQ5Y0Btk6/juuQUGcCw==",
+            "resolved": "https://github.com/DFE-Digital/dfe-analytics-dataform/archive/refs/tags/v2.4.2.tar.gz",
+            "integrity": "sha512-x3tm+KpwdeDoobAESpFGZY9TChmFOSAs+uQ8oKngdxxIc22MWjx+I2L2rEKjw6LEbAB8WXJENWh789s0ebvxqQ==",
             "dependencies": {
-                "@dataform/core": "3.0.2"
+                "@dataform/core": "^3.0.44"
             }
         }
     },
     "dependencies": {
         "@dataform/core": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/@dataform/core/-/core-3.0.2.tgz",
-            "integrity": "sha512-W1DQuv1vSsQgUPlNXuBTqa927FfNp5pNswOTz0wlX3cJTk5OT0UEENVmVJu/WIEdoVcCRTn8pn2dNNc1IjtMcA=="
+            "version": "3.0.45",
+            "resolved": "https://registry.npmjs.org/@dataform/core/-/core-3.0.45.tgz",
+            "integrity": "sha512-jXCF8fHbGE6ESBKwrDYGnoukzrr6bOpbEKhwacEGE4MKKkZHq7dfv+V/QNz7mDqaGQokLGLzHxcgzDYwgka++A=="
         },
         "dfe-analytics-dataform": {
-            "version": "https://github.com/DFE-Digital/dfe-analytics-dataform/archive/refs/tags/v2.1.0-pre4.tar.gz",
-            "integrity": "sha512-s3yN7m/01kHi7fq3PGYmgEKn1QMEz0z40S32wQVOX9XR69GD1RKiq96tT8DYZX/QZWShQ5Y0Btk6/juuQUGcCw==",
+            "version": "https://github.com/DFE-Digital/dfe-analytics-dataform/archive/refs/tags/v2.4.2.tar.gz",
+            "integrity": "sha512-x3tm+KpwdeDoobAESpFGZY9TChmFOSAs+uQ8oKngdxxIc22MWjx+I2L2rEKjw6LEbAB8WXJENWh789s0ebvxqQ==",
             "requires": {
-                "@dataform/core": "3.0.2"
+                "@dataform/core": "^3.0.44"
             }
         }
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "dependencies": {
-        "@dataform/core": "3.0.2",
-        "dfe-analytics-dataform": "https://github.com/DFE-Digital/dfe-analytics-dataform/archive/refs/tags/v2.1.0-pre4.tar.gz"
+        "@dataform/core": "3.0.45",
+        "dfe-analytics-dataform": "https://github.com/DFE-Digital/dfe-analytics-dataform/archive/refs/tags/v2.4.2.tar.gz"
     }
 }


### PR DESCRIPTION
- Amended teaching-qualifications to the latest version of dfe-analytics-dataform
- added in a new table to delete inactive datasets - standard on other projects

To stop the daily pipeline alerts:
- added new fields
- removed old fields
- added pii tags
- removed pii tags
- run migration functions to resolve sample data issues